### PR TITLE
Adds iperf prober

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -30,6 +30,7 @@ The other placeholders are specified separately.
   [ tcp: <tcp_probe> ]
   [ dns: <dns_probe> ]
   [ icmp: <icmp_probe> ]
+  [ iperf: <iperf_probe> ]
 
 ```
 

--- a/blackbox.yml
+++ b/blackbox.yml
@@ -31,3 +31,5 @@ modules:
       - expect: "^:[^ ]+ 001"
   icmp:
     prober: icmp
+  iperf:
+    prober: iperf

--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,7 @@ type Module struct {
 	TCP     TCPProbe      `yaml:"tcp,omitempty"`
 	ICMP    ICMPProbe     `yaml:"icmp,omitempty"`
 	DNS     DNSProbe      `yaml:"dns,omitempty"`
+	Iperf   IperfProbe    `yaml:"iperf,omitempty"`
 }
 
 type HTTPProbe struct {
@@ -185,6 +186,9 @@ type DNSProbe struct {
 	ValidateAnswer     DNSRRValidator   `yaml:"validate_answer_rrs,omitempty"`
 	ValidateAuthority  DNSRRValidator   `yaml:"validate_authority_rrs,omitempty"`
 	ValidateAdditional DNSRRValidator   `yaml:"validate_additional_rrs,omitempty"`
+}
+
+type IperfProbe struct {
 }
 
 type DNSRRValidator struct {

--- a/main.go
+++ b/main.go
@@ -60,10 +60,11 @@ var (
 	routePrefix   = kingpin.Flag("web.route-prefix", "Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.").PlaceHolder("<path>").String()
 
 	Probers = map[string]prober.ProbeFn{
-		"http": prober.ProbeHTTP,
-		"tcp":  prober.ProbeTCP,
-		"icmp": prober.ProbeICMP,
-		"dns":  prober.ProbeDNS,
+		"http":  prober.ProbeHTTP,
+		"tcp":   prober.ProbeTCP,
+		"icmp":  prober.ProbeICMP,
+		"dns":   prober.ProbeDNS,
+		"iperf": prober.ProbeIperf,
 	}
 )
 

--- a/prober/iperf.go
+++ b/prober/iperf.go
@@ -1,0 +1,78 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prober
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/blackbox_exporter/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func parseIperfOutput(output string) (float64, error) {
+	lines := strings.Split(output, "\n")
+	for _, l := range lines {
+		if strings.Contains(l, "receiver") {
+			cols := strings.Split(l, "  ")
+			for _, c := range cols {
+				if strings.Contains(c, "Kbits/sec") {
+					v := strings.ReplaceAll(c, "Kbits/sec", "")
+					return strconv.ParseFloat(strings.TrimSpace(v), 64)
+				}
+			}
+		}
+	}
+
+	return 0, errors.New("no throughput found")
+}
+
+// ProbeIperf measures the throughput between two hosts using the external iperf3 program.
+//
+func ProbeIperf(ctx context.Context, target string, module config.Module, registry *prometheus.Registry, logger log.Logger) (success bool) {
+	probeIperf := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "iperf_throughput_kbits_per_sec",
+		Help: "Throughput in kbits per second measured by iperf run",
+	})
+
+	registry.MustRegister(probeIperf)
+
+	iPath := "/usr/bin/iperf3" // TODO make this configurable
+
+	level.Info(logger).Log("msg", "iperf client started", "target", target)
+	c := exec.CommandContext(context.Background(), iPath, "-c", target, "-f", "k")
+	level.Info(logger).Log("msg", "iperf client finished", "target", target)
+
+	b, e := c.Output()
+	if e != nil {
+		level.Error(logger).Log("msg", "error running iperf", "target", target, "err", e)
+		return false
+	}
+
+	v, e := parseIperfOutput(string(b))
+	if e != nil {
+		level.Error(logger).Log("msg", "error parsing iperf output", "target", target, "err", e)
+		return false
+	}
+
+	level.Debug(logger).Log("msg", "successfully measured throughput", "target", target, "value", v)
+	probeIperf.Set(float64(v))
+
+	return true
+}


### PR DESCRIPTION
This sets up an extra prober that will call iperf3 (https://iperf.fr/) to measure bandwidth between two hosts. 

iperf3 is a tool @jroyalty mentioned that he's used to measure bandwidth before. It runs in both client and server modes. This exporter runs iperf3 in client mode against a host that needs to be running iperf3 in server mode. 

iperf3 does most of the interesting work here. All the exporter does is exec it as a separate process, parse stdout for the actual bandwidth measurement and then update a prometheus gauge. 